### PR TITLE
add placeholder for supporting CI on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+language: node_js
+node_js:
+  - "node"
+services:
+  - docker
+jobs:
+  include:
+    - stage: test
+      script: npm test
+    - stage: build docker image
+      script:
+        - docker build -t theo .
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - docker tag theo $DOCKER_USERNAME/theo
+        - docker push $DOCKER_USERNAME/theo

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ services:
   - docker
 jobs:
   include:
-    - stage: test
-      script: npm test
+# uncomment once test are implemented
+#    - stage: test
+#      script: npm test
     - stage: build docker image
       script:
         - docker build -t theo .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Theo
 
+[![Build Status](https://travis-ci.com/gizero/theo-node.svg?branch=travis-ci)](https://travis-ci.com/gizero/theo-node)
+
 Theo is a public key manager, you can use it as replacement for all of your `authorized_keys`   
 It allows you to set fine permissions (specific user and host) or to use wildcard (ex, using host `*.test.sample.com`) 
 


### PR DESCRIPTION
Once Travis support is enabled for your repo, this PR adds:
*  simple `.travis.yml` with support for building and pushing an image to the Docker hub. `DOCKER_USERNAME` and `DOCKER_PASSWORD` must be populated with your own credentials for your project in Travis
*  placeholder of a pipeline stage that runs tests is also provided (commented out to avoid pipeline failure)
*  `README.md` is updated to show a badge with the status of builds on Travis.