### PR TITLE
Multistage dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,8 @@
 .gitignore
 .idea
 .npmrc
+node_modules
+build
 README.md
 data
 env.sample
-build/test

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,4 @@
 README.md
 data
 env.sample
-src
 build/test
-package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,10 @@ jobs:
         - docker stop mariadb
     - stage: build
       script:
-        - docker run --rm -v $PWD:/usr/local/src -w /usr/local/src node:8-alpine sh -c 'npm i -g npm && npm i --no-optional && npm run build'
         - docker build -t theo .
     - stage: push-image
       if: tag IS present
       script:
-      - docker run --rm -v $PWD:/usr/local/src -w /usr/local/src node:8-alpine sh -c 'npm i -g npm && npm i --no-optional && npm run build'
       - docker build -t theo .
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - docker tag theo $DOCKER_IMAGE:$TRAVIS_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
-FROM node:8-alpine
+# builder image
+FROM node:8-alpine AS builder
 
-EXPOSE 9100
-
-
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ARG NODE_ENV
-ENV NODE_ENV $NODE_ENV
+COPY package*.json ./
 
-COPY . /usr/src/app
+RUN npm install --no-optional
+
+COPY . .
+
+RUN npm run build
+
+# production image
+FROM node:8-alpine
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install --no-optional &&\
+    npm cache clean --force
+
+COPY --from=builder /usr/src/app/build ./build/
+
+EXPOSE 9100
 
 CMD [ "npm", "start" ]

--- a/buildDockerImage.sh
+++ b/buildDockerImage.sh
@@ -8,9 +8,6 @@ DOCKER_TAG=$(cat package.json \
   | sed 's/[",]//g' \
   | tr -d '[[:space:]]')
 
-rm -rf build node_modules
-docker run --rm -v $PWD:/usr/local/src -w /usr/local/src node:8-alpine sh -c 'npm i -g npm && npm i --no-optional && npm run build' 
-
 docker build -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
 
 if [ "$1" = "push" ]; then


### PR DESCRIPTION
Use a multi-stage `Dockerfile` to build a lean production image entirely within containers with no need to "park" build artefacts within the host filesystem. This also updates Travis CI to take advantage of the new `Dockerfile` 